### PR TITLE
make hyperpar definitions consistent; rename tau -> tau2 for clarity

### DIFF
--- a/markdowns/2020_04_01.Rmd
+++ b/markdowns/2020_04_01.Rmd
@@ -22,12 +22,12 @@ library(haven)
 library(survival)
 library(parallel)
 library(demogsurv)
-devtools::load_all("~/Documents/GitHub/naomi")
-# library(naomi)
+## devtools::load_all("~/Documents/GitHub/naomi")
+library(naomi)
 library(here)
 
-naomi_data_path <- "~/Documents/GitHub/naomi-data"
-# naomi_data_path <- "~/GitHub/naomi-data"
+## naomi_data_path <- "~/Documents/GitHub/naomi-data"
+naomi_data_path <- "~/naomi-data"
 
 source(here("R/inputs.R"))
 source(here("R/fertility_funs.R"))
@@ -111,7 +111,9 @@ f$par.full <- obj$env$last.par
 
 fit <- c(f, obj = list(obj))
 fit$sdreport <- sdreport(fit$obj, fit$par)
-fit <- sample_tmb_test(fit)
+
+class(fit) <- "naomi_fit"  # this is hacky...
+fit <- sample_tmb(fit)
 
 qtls <- apply(fit$sample$lambda_out, 1, quantile, c(0.025, 0.5, 0.975))
 
@@ -126,7 +128,16 @@ formula <- births ~
   f(id.period, model="rw2") + 
   f(id.district, model="bym2", graph=here("countries/ZWE/adj/ZWE_admin2.adj"))
 
-inla_mod <- run_mod_nat(formula, asfr)
+## inla_mod <- run_mod_nat(formula, asfr)
+
+inla_mod <- inla(formula, family="poisson", data=asfr, E=pys,
+                 control.family=list(link='log'),
+                 control.predictor=list(compute=TRUE, link=1),
+                 control.inla = list(strategy = "gaussian", int.strategy = "eb"),
+                 ## control.compute=list(config = TRUE, dic= TRUE, cpo=TRUE),
+                 control.compute=list(config = TRUE),
+                 verbose=TRUE)
+
 inla_res <- get_mod_results_test(inla_mod, asfr)
 
 ```
@@ -164,19 +175,19 @@ inla_untransformed_hyper <- list(
 )
 
 gridExtra::grid.arrange(
-data.frame(val=fit$sample$log_tau_rw_age, source = "tmb log tau") %>%
+data.frame(val=fit$sample$log_tau2_rw_age, source = "tmb log tau^2") %>%
   ggplot(aes(color=source)) +
     geom_density(aes(x=val)) +
     geom_point(data=inla_untransformed_hyper$age %>% mutate(source = "INLA log precision"), aes(x=x, y=y)) +
     labs(title="Age"),
 
-data.frame(val=fit$sample$log_tau_rw_period, source = "tmb log tau") %>%
+data.frame(val=fit$sample$log_tau2_rw_period, source = "tmb log tau^2") %>%
   ggplot(aes(color=source)) +
   geom_density(aes(x=val)) +
   geom_point(data=inla_untransformed_hyper$period %>% mutate(source = "INLA log precision"), aes(x=x, y=y)) +
   labs(title="Period"),
 
-data.frame(val=fit$sample$log_sigma_spatial, source = "tmb log sigma") %>%
+data.frame(val=fit$sample$log_tau2_spatial, source = "tmb log tau^2") %>%
   ggplot(aes(color=source)) +
   geom_density(aes(x=val)) +
   geom_point(data=inla_untransformed_hyper$district %>% mutate(source = "INLA log precision"), aes(x=x, y=y)) +
@@ -188,4 +199,10 @@ data.frame(val=fit$sample$logit_spatial_rho, source = "tmb logit rho") %>%
   geom_point(data=inla_untransformed_hyper$district_phi %>% mutate(source = "INLA logit phi"), aes(x=x, y=y)) +
   labs(title="Rho (tmb), phi (INLA")
 )
+```
+
+The log precisions from INLA are close to -2 times the log standard devations from TMB.
+```{r compare_hyperpar}
+inla_mod$internal.summary.hyperpar
+fit$sdreport
 ```

--- a/tmb/fertility_tmb_dev.cpp
+++ b/tmb/fertility_tmb_dev.cpp
@@ -98,7 +98,6 @@ Type objective_function<Type>::operator() ()
 
   //RW AGE
   Type sigma_rw_age = exp(log_sigma_rw_age);
-  Type log_tau_rw_age(log(1/(sigma_rw_age * sigma_rw_age)));
   nll -= dnorm(sigma_rw_age, Type(0), Type(2.5), true) + log_sigma_rw_age;
 
   // Type prec_rw_age = exp(log_prec_rw_age);
@@ -110,7 +109,6 @@ Type objective_function<Type>::operator() ()
 
   // RW PERIOD
   Type sigma_rw_period = exp(log_sigma_rw_period);
-  Type log_tau_rw_period(log(1/(sigma_rw_period * sigma_rw_period)));
   nll -= dnorm(sigma_rw_period, Type(0), Type(2.5), true) + log_sigma_rw_period;
 
   // Type prec_rw_period = exp(log_prec_rw_period);
@@ -162,8 +160,8 @@ Type objective_function<Type>::operator() ()
 
   vector<Type> log_lambda(
                      X_mf * beta_mf
-                     + Z_age * u_age * 1/(sigma_rw_age * sigma_rw_age)     // Age RW1
-                     + Z_period * u_period * 1/(sigma_rw_period * sigma_rw_period)
+                     + Z_age * u_age * sigma_rw_age     // Age RW1
+                     + Z_period * u_period * sigma_rw_period
                      + Z_spatial * spatial
                      // + Z_interaction1 * eta1_v * 1/sigma_eta1
                      // + Z_interaction2 * eta2_v
@@ -200,13 +198,20 @@ Type objective_function<Type>::operator() ()
   vector<Type> population_out(A_out * pop);
   vector<Type> lambda_out(births_out / population_out);
 
+  Type log_tau2_rw_age(-2 * log_sigma_rw_age);
+  Type log_tau2_rw_period(-2 * log_sigma_rw_period);
+  Type log_tau2_spatial(-2 * log_sigma_spatial);
+    
   REPORT(lambda_out);
   REPORT(log_sigma_rw_period);
   REPORT(log_sigma_rw_age);
   REPORT(log_sigma_spatial);
   REPORT(logit_spatial_rho);
-  REPORT(log_tau_rw_period);
-  REPORT(log_tau_rw_age);
+
+  REPORT(log_tau2_rw_age);
+  REPORT(log_tau2_rw_period);
+  REPORT(log_tau2_spatial);
+  
   // REPORT(log_tau_rw_period);
   // REPORT(tau_rw_age);
   // ADREPORT(prec_eta1);


### PR DESCRIPTION
* Standard deviations and precisions are coded consistently with INLA and TMB now.
* In TMB, precision `tau` renamed as `tau2` for clarity.

Not done:

* The BYM2 `logit phi` parameter in INLA does not match `logit rho` in TMB, but suspecting (hoping) INLA has simply parameterised the other way around (so rho = 1-phi).
* HTML is not regenerated.
* Note the `sample_tmb` is sampling random effects only, so there's actually no variation in the TMB values being plotted (i.e. `fit$sample$log_tau2_rw_age` is a single value repeated)